### PR TITLE
Minor fix

### DIFF
--- a/js/src/helper.ts
+++ b/js/src/helper.ts
@@ -18,9 +18,9 @@ export function serializePath(path: string): Buffer {
     let value = 0
     let child = pathArray[i]
     if (child.endsWith("'")) {
-      value += HARDENED
       child = child.slice(0, -1)
     }
+    value += HARDENED
 
     const childNumber = Number(child)
 

--- a/zemu/package.json
+++ b/zemu/package.json
@@ -20,7 +20,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.27.1",
     "@types/node": "^16.10.3",
     "@zondax/ledger-tezos": "link:../js",
-    "@zondax/zemu": "^0.30"
+    "@zondax/zemu": "^0.32"
   },
   "devDependencies": {
     "@taquito/ledger-signer": "^10.2.0",


### PR DESCRIPTION
Minor change to make if work for paths like:
path1 = "m/44'/1729'/0'/0'";
path2 = "m/44'/1729'/0/0";

<!-- ClickUpRef: 2phwmc3 -->
:link: [zboto Link](https://app.clickup.com/t/2phwmc3)